### PR TITLE
WEB-38: Changing title across the frontend!

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # The path '/ollama' will be redirected to the specified backend URL
 OLLAMA_BASE_URL='http://localhost:11434'
 
+# Application name
+WEBUI_NAME='Channel AI'
+
 OPENAI_API_BASE_URL=''
 OPENAI_API_KEY=''
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -107,9 +107,7 @@ for source in log_sources:
 log.setLevel(SRC_LOG_LEVELS["CONFIG"])
 
 
-WEBUI_NAME = os.environ.get("WEBUI_NAME", "Open WebUI")
-if WEBUI_NAME != "Open WebUI":
-    WEBUI_NAME += " (Open WebUI)"
+WEBUI_NAME = os.environ.get("WEBUI_NAME", "Channel AI")
 
 WEBUI_FAVICON_URL = "https://openwebui.com/favicon.png"
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,6 +18,7 @@ services:
       - ENABLE_SIGNUP=true
       - OPEN_WEBUI_PORT=8080
       - NODE_OPTIONS=--max-old-space-size=16384
+      - WEBUI_NAME=Channel AI
       - AUTH0_DOMAIN=channelai.us.auth0.com
       - AUTH0_CLIENT_ID=cEewmmCzsdXlyMjYPaVL0R0oG5cUch8S
       - AUTH0_CLIENT_SECRET=ENwpH_67wF05aaFnd5oTHFWmSu9c1bbtdYAFy1mGV-n3L-yJT_mQdHCZ4ilPorOJ

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
     environment:
       - 'OLLAMA_BASE_URL=http://ollama:11434'
       - 'WEBUI_SECRET_KEY='
+      - 'WEBUI_NAME=Channel AI'
     extra_hosts:
       - host.docker.internal:host-gateway
     restart: unless-stopped

--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
 		<link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
 		<link rel="shortcut icon" href="/favicon/favicon.ico" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
-		<meta name="apple-mobile-web-app-title" content="Open WebUI" />
+		<meta name="apple-mobile-web-app-title" content="Channel AI" />
 		<link rel="manifest" href="/favicon/site.webmanifest" />
 		<meta
 			name="viewport"
@@ -14,11 +14,11 @@
 		/>
 		<meta name="theme-color" content="#171717" />
 		<meta name="robots" content="noindex,nofollow" />
-		<meta name="description" content="Open WebUI" />
+		<meta name="description" content="Channel AI" />
 		<link
 			rel="search"
 			type="application/opensearchdescription+xml"
-			title="Open WebUI"
+			title="Channel AI"
 			href="/opensearch.xml"
 		/>
 		<script src="/static/loader.js" defer></script>
@@ -77,7 +77,7 @@
 			})();
 		</script>
 
-		<title>Open WebUI</title>
+		<title>Channel AI</title>
 
 		%sveltekit.head%
 	</head>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,7 @@
 import { browser, dev } from '$app/environment';
 // import { version } from '../../package.json';
 
-export const APP_NAME = 'Open WebUI';
+export const APP_NAME = 'Channel AI';
 
 export const WEBUI_HOSTNAME = browser ? (dev ? `${location.hostname}:8080` : ``) : '';
 export const WEBUI_BASE_URL = browser ? (dev ? `http://${WEBUI_HOSTNAME}` : ``) : ``;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -227,7 +227,7 @@
 				if (done) {
 					if ($isLastActiveTab) {
 						if ($settings?.notificationEnabled ?? false) {
-							new Notification(`${title} | Open WebUI`, {
+							new Notification(`${title} | Channel AI`, {
 								body: content,
 								icon: `${WEBUI_BASE_URL}/static/favicon.png`
 							});
@@ -373,7 +373,7 @@
 			if (type === 'message') {
 				if ($isLastActiveTab) {
 					if ($settings?.notificationEnabled ?? false) {
-						new Notification(`${data?.user?.name} (#${event?.channel?.name}) | Open WebUI`, {
+						new Notification(`${data?.user?.name} (#${event?.channel?.name}) | Channel AI`, {
 							body: data?.content,
 							icon: data?.user?.profile_image_url ?? `${WEBUI_BASE_URL}/static/favicon.png`
 						});

--- a/static/favicon/site.webmanifest
+++ b/static/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Open WebUI",
-  "short_name": "WebUI",
+  "name": "Channel AI",
+  "short_name": "Channel",
   "icons": [
     {
       "src": "/favicon/web-app-manifest-192x192.png",

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,6 +1,6 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-<ShortName>Open WebUI</ShortName>
-<Description>Search Open WebUI</Description>
+<ShortName>Channel AI</ShortName>
+<Description>Search Channel AI</Description>
 <InputEncoding>UTF-8</InputEncoding>
 <Image width="16" height="16" type="image/x-icon">http://localhost:5137/favicon.png</Image>
 <Url type="text/html" method="get" template="http://localhost:5137/?q={searchTerms}"/>


### PR DESCRIPTION
Set the application name 'Channel AI' in environment variables and Docker configurations for consistent branding across all deployment methods. Updated .env.example, docker-compose files, and ensured backend/env.py uses the new default value.