### PR TITLE
[WEB-52] Only allow Auth0 sign-in by default, hide username/password behind URL parameter

### DIFF
--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -22,6 +22,7 @@
 	let loaded = false;
 
 	let mode = $config?.features.enable_ldap ? 'ldap' : 'signin';
+	let showAdminLogin = false;
 
 	let name = '';
 	let email = '';
@@ -166,6 +167,8 @@
 
 		loaded = true;
 		setLogoImage();
+		
+		showAdminLogin = querystringValue('showadminlogin') === 'true';
 
 		if (($config?.features.auth_trusted_header ?? false) || $config?.features.auth === false) {
 			await signInHandler();
@@ -259,7 +262,7 @@
 								{/if}
 							</div>
 
-							{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
+							{#if (($config?.features.enable_login_form || $config?.features.enable_ldap) && (showAdminLogin || ($config?.onboarding ?? false)))}
 								<div class="flex flex-col mt-4">
 									{#if mode === 'signup'}
 										<div class="mb-2">
@@ -319,7 +322,7 @@
 								</div>
 							{/if}
 							<div class="mt-5">
-								{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
+								{#if (($config?.features.enable_login_form || $config?.features.enable_ldap) && (showAdminLogin || ($config?.onboarding ?? false)))}
 									{#if mode === 'ldap'}
 										<button
 											class="bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
@@ -368,7 +371,7 @@
 						{#if Object.keys($config?.oauth?.providers ?? {}).length > 0}
 							<div class="inline-flex items-center justify-center w-full">
 								<hr class="w-32 h-px my-4 border-0 dark:bg-gray-100/10 bg-gray-700/10" />
-								{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
+								{#if (($config?.features.enable_login_form || $config?.features.enable_ldap) && showAdminLogin)}
 									<span
 										class="px-3 text-sm font-medium text-gray-900 dark:text-white bg-transparent"
 										>{$i18n.t('or')}</span
@@ -479,7 +482,7 @@
 							</div>
 						{/if}
 
-						{#if $config?.features.enable_ldap && $config?.features.enable_login_form}
+						{#if ($config?.features.enable_ldap && $config?.features.enable_login_form && showAdminLogin)}
 							<div class="mt-2">
 								<button
 									class="flex justify-center items-center text-xs w-full text-center underline"


### PR DESCRIPTION
## Description
This PR modifies the authentication screen to only show Auth0 as a login option by default, improving security by reducing exposure of the username/password login form.

## Changes
- Hide username/password login by default for regular users
- Only show Auth0 login option for normal usage
- Add special URL parameter (`?showadminlogin=true`) to reveal username/password login for administrative access
- Maintain existing behavior for the onboarding process

## Testing
- ✅ Regular users visiting the login page will only see the Auth0 login option
- ✅ Admins can access the username/password login by adding `?showadminlogin=true` to the URL
- ✅ Onboarding flow remains intact
