### PR TITLE
WEB-53: Disable Settings option in user account flyout menu

### DIFF
--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -37,6 +37,7 @@
 			align="start"
 			transition={(e) => fade(e, { duration: 100 })}
 		>
+			<!-- Settings button hidden as per WEB-53
 			<button
 				class="flex rounded-md py-2 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
 				on:click={async () => {
@@ -71,6 +72,7 @@
 				</div>
 				<div class=" self-center truncate">{$i18n.t('Settings')}</div>
 			</button>
+			-->
 
 			<button
 				class="flex rounded-md py-2 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"


### PR DESCRIPTION
## Summary
This PR removes the Settings option from the user account flyout menu as requested in WEB-53.

## Changes
- Commented out the Settings button in the user flyout menu (UserMenu.svelte)
- Added a comment to indicate that the button was hidden as per WEB-53 requirement

## Testing
- Verified that the Settings option no longer appears in the user account flyout menu
- Development server runs without errors