### PR TITLE
WEB-54: Disable Active Users section in user account flyout menu

### DIFF
--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -189,6 +189,7 @@
 				<div class=" self-center truncate">{$i18n.t('Sign Out')}</div>
 			</button>
 
+			<!-- Active Users section hidden as per WEB-54
 			{#if $activeUserIds?.length > 0}
 				<hr class=" border-gray-100 dark:border-gray-850 my-1 p-0" />
 
@@ -218,6 +219,7 @@
 					</div>
 				</Tooltip>
 			{/if}
+			-->
 
 			<!-- <DropdownMenu.Item class="flex items-center px-3 py-2 text-sm ">
 				<div class="flex items-center">Profile</div>


### PR DESCRIPTION
## Summary
This PR removes the Active Users section from the user account flyout menu as requested in WEB-54.

## Changes
- Commented out the Active Users section in the user flyout menu (UserMenu.svelte)
- Added a comment to indicate that the section was hidden as per WEB-54 requirement

## Testing
- Verified that the Active Users section no longer appears in the user account flyout menu
- Development server runs without errors