### PR TITLE
WEB-56 Remove Open Web UI references from error page

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -731,7 +731,7 @@ if CUSTOM_NAME:
 LICENSE_KEY = os.environ.get("LICENSE_KEY", "")
 
 ####################################
-# STORAGE PROVIDER
+# STORAGE_PROVIDER
 ####################################
 
 STORAGE_PROVIDER = os.environ.get("STORAGE_PROVIDER", "local")  # defaults to local, s3
@@ -1117,7 +1117,7 @@ ENABLE_ADMIN_CHAT_ACCESS = (
 ENABLE_COMMUNITY_SHARING = PersistentConfig(
     "ENABLE_COMMUNITY_SHARING",
     "ui.enable_community_sharing",
-    os.environ.get("ENABLE_COMMUNITY_SHARING", "True").lower() == "true",
+    os.environ.get("ENABLE_COMMUNITY_SHARING", "False").lower() == "true",
 )
 
 ENABLE_MESSAGE_RATING = PersistentConfig(

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -731,7 +731,7 @@ if CUSTOM_NAME:
 LICENSE_KEY = os.environ.get("LICENSE_KEY", "")
 
 ####################################
-# STORAGE_PROVIDER
+# STORAGE PROVIDER
 ####################################
 
 STORAGE_PROVIDER = os.environ.get("STORAGE_PROVIDER", "local")  # defaults to local, s3
@@ -1117,7 +1117,7 @@ ENABLE_ADMIN_CHAT_ACCESS = (
 ENABLE_COMMUNITY_SHARING = PersistentConfig(
     "ENABLE_COMMUNITY_SHARING",
     "ui.enable_community_sharing",
-    os.environ.get("ENABLE_COMMUNITY_SHARING", "False").lower() == "true",
+    os.environ.get("ENABLE_COMMUNITY_SHARING", "True").lower() == "true",
 )
 
 ENABLE_MESSAGE_RATING = PersistentConfig(

--- a/src/routes/error/+page.svelte
+++ b/src/routes/error/+page.svelte
@@ -25,25 +25,19 @@
 						{$i18n.t('{{webUIName}} Backend Required', { webUIName: $WEBUI_NAME })}
 					</div>
 
-					<div class=" mt-4 text-center text-sm w-full">
+					<div class="mt-4 text-center text-sm w-full">
 						{$i18n.t(
-							"Oops! You're using an unsupported method (frontend only). Please serve the WebUI from the backend."
+							"Oops! Something went wrong. We're having trouble connecting to the server."
 						)}
 
 						<br class=" " />
 						<br class=" " />
-						<a
-							class=" font-semibold underline"
-							href="https://github.com/open-webui/open-webui#how-to-install-"
-							target="_blank">{$i18n.t('See readme.md for instructions')}</a
-						>
-						{$i18n.t('or')}
-						<a class=" font-semibold underline" href="https://discord.gg/5rJgQTnV4s" target="_blank"
-							>{$i18n.t('join our Discord for help.')}</a
-						>
+						<div class="font-medium">
+							{$i18n.t('Please check your connection and try again later.')}
+						</div>
 					</div>
 
-					<div class=" mt-6 mx-auto relative group w-fit">
+					<div class="mt-6 mx-auto relative group w-fit">
 						<button
 							class="relative z-20 flex px-5 py-2 rounded-full bg-gray-100 hover:bg-gray-200 transition font-medium text-sm"
 							on:click={() => {


### PR DESCRIPTION
Removed links to Open Web UI GitHub repository and Discord from the error page
Replaced the existing error message with a generic message: "Oops! Something went wrong. We're having trouble connecting to the server."
Added a user-friendly instruction: "Please check your connection and try again later."