### PR TITLE
Fix voice recording functionality by adding missing audio dependencies (WEB-58)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -99,6 +99,8 @@ pytube==15.0.0
 
 extract_msg
 pydub
+av
+ctranslate2<5,>=4.0
 duckduckgo-search~=7.3.2
 
 ## Google Drive


### PR DESCRIPTION
Issue
The voice recording feature in the message input component was not working, resulting in a "[ERROR: 400: [ERROR: No module named 'av']]" error followed by a "[ERROR: 400: [ERROR: No module named 'ctranslate2']]" error when attempting to use the feature.

Solution
Added the missing Python dependencies to the backend requirements.txt file:

Added av package, which is a Python binding for FFmpeg used for audio processing
Added ctranslate2<5,>=4.0 package, which is required by faster-whisper for audio transcription
Testing
After adding these dependencies and restarting the development server, the voice recording functionality works as expected. The audio can now be properly processed and transcribed by the backend server.

Impact
This fix ensures that users can record voice messages in the chat interface, enabling a more versatile communication experience without encountering errors.

Related Tickets
Fixes WEB-58