### PR TITLE
WEB-69: Limit multimodel chat model selection to a maximum of 3 models

### DIFF
--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -62,7 +62,11 @@
 							class=" "
 							{disabled}
 							on:click={() => {
-								selectedModels = [...selectedModels, ''];
+								if (selectedModels.length < 3) {
+									selectedModels = [...selectedModels, ''];
+								} else {
+									toast.error($i18n.t('Maximum of 3 models allowed for multimodel chat'));
+								}
 							}}
 							aria-label="Add Model"
 						>


### PR DESCRIPTION
## Description
This PR implements a 3-model limit for multimodel chats to prevent users from selecting more than 3 models simultaneously. When users attempt to add a 4th model, they now receive an error toast notification informing them of this limitation.

## Changes Made
- Added a condition in the ModelSelector component to check if the user already has 3 models selected before allowing them to add another one
- Added an error toast message that displays when users try to exceed the limit

## Testing
- Verified that users can still select up to 3 models for multimodel chat
- Confirmed that attempting to add a 4th model triggers the error message
- Ensured existing functionality for 1-3 model selection remains intact

## Related Issue
Resolves WEB-69