### PR TITLE
Fix Auth0 logout redirect URL for production

### DIFF
--- a/src/lib/services/auth0.ts
+++ b/src/lib/services/auth0.ts
@@ -6,8 +6,9 @@ const AUTH0_DOMAIN = 'channelai.us.auth0.com';
 const AUTH0_CLIENT_ID = 'cEewmmCzsdXlyMjYPaVL0R0oG5cUch8S';
 
 // Force consistent domain usage 
-// Note: In production, consider using an environment variable to configure this
-const PREFERRED_DOMAIN = 'localhost';  // or '127.0.0.1' based on Auth0 configuration
+// Use the actual domain in production, fallback to localhost for development
+const isDevelopment = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+const PREFERRED_DOMAIN = isDevelopment ? 'localhost' : window.location.hostname;
 
 let auth0Client: Auth0Client | null = null;
 
@@ -16,7 +17,7 @@ let auth0Client: Auth0Client | null = null;
  */
 const getConsistentReturnUrl = (): string => {
   // Get the current origin but ensure we use the preferred domain
-  const port = window.location.port ? `:${window.location.port}` : '';
+  const port = isDevelopment && window.location.port ? `:${window.location.port}` : '';
   const protocol = window.location.protocol;
   
   // Construct a consistent URL using the preferred domain


### PR DESCRIPTION
## Problem
When users try to log out in the production environment (chat.channel.bot), they're redirected to 'https://localhost/auth' instead of the correct production URL, causing an Auth0 error:

> invalid_request: The "returnTo" querystring parameter "https://localhost/auth" is not defined as a valid URL in "Allowed Logout URLs".

## Solution
- Updated auth0.ts to use the actual hostname in production instead of hardcoded 'localhost'
- Added environment detection to only include port number in development mode
- Ensures proper returnTo URL for both development (localhost:port) and production (actual domain) environments

This fix ensures the Auth0 logout process redirects to the correct URL that is already configured in the Auth0 allowed logout URLs.