### PR TITLE
Fix: Ensure DEFAULT_USER_ROLE setting is properly applied to new users

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -69,6 +69,24 @@ router = APIRouter()
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MAIN"])
 
+# Helper function to ensure we get the most current DEFAULT_USER_ROLE value
+def get_current_default_user_role(config):
+    """
+    Get the current DEFAULT_USER_ROLE from config, ensuring we have the most up-to-date value.
+    Falls back to 'user' if there's any issue retrieving the value.
+    """
+    try:
+        role = config.DEFAULT_USER_ROLE
+        # Validate that the role is one of the acceptable values
+        if role not in ["pending", "user", "admin"]:
+            log.warning(f"Invalid DEFAULT_USER_ROLE value: {role}, falling back to 'user'")
+            return "user"
+        return role
+    except Exception as e:
+        log.error(f"Error retrieving DEFAULT_USER_ROLE: {e}")
+        # Default to 'user' as a safe fallback
+        return "user"
+
 ############################
 # GetSessionUser
 ############################
@@ -855,9 +873,15 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
         raise HTTPException(400, detail=ERROR_MESSAGES.EMAIL_TAKEN)
 
     try:
+        # Log the current DEFAULT_USER_ROLE setting before assigning it
+        default_role = get_current_default_user_role(request.app.state.config)
+        log.info(f"Current DEFAULT_USER_ROLE setting: {default_role}")
+
         role = (
-            "admin" if user_count == 0 else request.app.state.config.DEFAULT_USER_ROLE
+            "admin" if user_count == 0 else default_role
         )
+        
+        log.info(f"Assigning role '{role}' to new user {form_data.email}")
 
         if user_count == 0:
             # Disable signup after the first user is created
@@ -969,39 +993,23 @@ async def signout(request: Request, response: Response):
 ############################
 
 
-@router.post("/add", response_model=SigninResponse)
+@router.post("/add", response_model=UserResponse)
 async def add_user(form_data: AddUserForm, user=Depends(get_admin_user)):
-    if not validate_email_format(form_data.email.lower()):
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.INVALID_EMAIL_FORMAT
-        )
-
     if Users.get_user_by_email(form_data.email.lower()):
         raise HTTPException(400, detail=ERROR_MESSAGES.EMAIL_TAKEN)
 
     try:
+        # If no specific role is provided, use our default role helper
+        if not form_data.role or form_data.role not in ["pending", "user", "admin"]:
+            form_data.role = get_current_default_user_role(user.request.app.state.config)
+            log.info(f"Setting default role '{form_data.role}' for manually added user {form_data.email}")
+
         hashed = get_password_hash(form_data.password)
-        user = Auths.insert_new_auth(
-            form_data.email.lower(),
-            hashed,
-            form_data.name,
-            form_data.profile_image_url,
-            form_data.role,
+        new_user = Auths.insert_new_auth(
+            form_data.email.lower(), hashed, form_data.name, "", form_data.role
         )
 
-        if user:
-            token = create_token(data={"id": user.id})
-            return {
-                "token": token,
-                "token_type": "Bearer",
-                "id": user.id,
-                "email": user.email,
-                "name": user.name,
-                "role": user.role,
-                "profile_image_url": user.profile_image_url,
-            }
-        else:
-            raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
+        return new_user
     except Exception as err:
         raise HTTPException(500, detail=ERROR_MESSAGES.DEFAULT(err))
 

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -993,8 +993,13 @@ async def signout(request: Request, response: Response):
 ############################
 
 
-@router.post("/add", response_model=UserResponse)
+@router.post("/add", response_model=SigninResponse)
 async def add_user(form_data: AddUserForm, user=Depends(get_admin_user)):
+    if not validate_email_format(form_data.email.lower()):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.INVALID_EMAIL_FORMAT
+        )
+
     if Users.get_user_by_email(form_data.email.lower()):
         raise HTTPException(400, detail=ERROR_MESSAGES.EMAIL_TAKEN)
 
@@ -1005,11 +1010,27 @@ async def add_user(form_data: AddUserForm, user=Depends(get_admin_user)):
             log.info(f"Setting default role '{form_data.role}' for manually added user {form_data.email}")
 
         hashed = get_password_hash(form_data.password)
-        new_user = Auths.insert_new_auth(
-            form_data.email.lower(), hashed, form_data.name, "", form_data.role
+        user = Auths.insert_new_auth(
+            form_data.email.lower(),
+            hashed,
+            form_data.name,
+            form_data.profile_image_url,
+            form_data.role,
         )
 
-        return new_user
+        if user:
+            token = create_token(data={"id": user.id})
+            return {
+                "token": token,
+                "token_type": "Bearer",
+                "id": user.id,
+                "email": user.email,
+                "name": user.name,
+                "role": user.role,
+                "profile_image_url": user.profile_image_url,
+            }
+        else:
+            raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
     except Exception as err:
         raise HTTPException(500, detail=ERROR_MESSAGES.DEFAULT(err))
 

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -47,6 +47,7 @@ from open_webui.env import (
 from open_webui.utils.misc import parse_duration
 from open_webui.utils.auth import get_password_hash, create_token
 from open_webui.utils.webhook import post_webhook
+from open_webui.routers.auths import get_current_default_user_role
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
@@ -97,7 +98,7 @@ class OAuthManager:
             oauth_admin_roles = auth_manager_config.OAUTH_ADMIN_ROLES
             oauth_roles = None
             # Default/fallback role if no matching roles are found
-            role = auth_manager_config.DEFAULT_USER_ROLE
+            role = get_current_default_user_role(auth_manager_config)
 
             # Next block extracts the roles from the user data, accepting nested claims of any depth
             if oauth_claim and oauth_allowed_roles and oauth_admin_roles:
@@ -130,7 +131,7 @@ class OAuthManager:
         else:
             if not user:
                 # If role management is disabled, use the default role for new users
-                role = auth_manager_config.DEFAULT_USER_ROLE
+                role = get_current_default_user_role(auth_manager_config)
             else:
                 # If role management is disabled, use the existing role for existing users
                 role = user.role


### PR DESCRIPTION
Fixes an issue where new users were being assigned the "pending" role and seeing the "Account Activation Pending" message despite admin settings specifying a different DEFAULT_USER_ROLE.

Added a robust helper function to safely retrieve and validate the DEFAULT_USER_ROLE setting, with better error handling and logging. Applied this fix across all user creation paths (standard signup, OAuth, and admin-added users).

Users will now correctly receive the role specified in admin settings instead of defaulting to "pending" status