### PR TITLE
Fix model visibility by properly merging workspace settings in global model store

### DIFF
--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -1,5 +1,8 @@
 import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
 import { getOpenAIModelsDirect } from './openai';
+import { getBaseModels as getBaseModelsFromApi } from './models';
+
+export const getBaseModels = getBaseModelsFromApi;
 
 export const getModels = async (
 	token: string = '',

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -12,7 +12,7 @@
 
 	import { getKnowledgeBases } from '$lib/apis/knowledge';
 	import { getFunctions } from '$lib/apis/functions';
-	import { getModels, getVersionUpdates } from '$lib/apis';
+	import { getModels, getVersionUpdates, getBaseModels } from '$lib/apis';
 	import { getAllTags } from '$lib/apis/chats';
 	import { getPrompts } from '$lib/apis/prompts';
 	import { getTools } from '$lib/apis/tools';
@@ -94,12 +94,62 @@
 				settings.set(localStorageSettings);
 			}
 
-			models.set(
-				await getModels(
+			console.log('[App] Initializing model store with proper workspace overrides');
+			
+			try {
+				// Get both raw models and workspace-specific model settings
+				const baseModels = await getModels(
 					localStorage.token,
-					$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
-				)
-			);
+					$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null),
+					true // Important: Use base=true to get unfiltered models
+				);
+				
+				const workspaceModels = await getBaseModels(localStorage.token);
+				
+				console.log('[App] Fetched base models:', baseModels.length);
+				console.log('[App] Fetched workspace models:', workspaceModels.length);
+				
+				// Apply workspace settings to base models (same logic as in admin Models.svelte)
+				const mergedModels = baseModels.map(m => {
+					const workspaceModel = workspaceModels.find(wm => wm.id === m.id);
+					
+					if (workspaceModel) {
+						// Workspace settings override base model properties
+						return {
+							...m,
+							...workspaceModel
+						};
+					} else {
+						// Default values for models without workspace settings
+						return {
+							...m,
+							id: m.id,
+							name: m.name,
+							is_active: true // Default to active if no workspace setting
+						};
+					}
+				});
+				
+				console.log('[App] Models after merging workspace settings:', 
+					mergedModels.length,
+					'Active:', mergedModels.filter(m => m.is_active !== false).length,
+					'Inactive:', mergedModels.filter(m => m.is_active === false).length
+				);
+				
+				// Set the merged models in the store
+				models.set(mergedModels);
+			} catch (error) {
+				console.error('[App] Error initializing models with workspace settings:', error);
+				
+				// Fallback to original method if there's an error
+				models.set(
+					await getModels(
+						localStorage.token,
+						$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
+					)
+				);
+			}
+			
 			banners.set(await getBanners(localStorage.token));
 			tools.set(await getTools(localStorage.token));
 


### PR DESCRIPTION
Problem
We identified a critical bug where disabled models in the admin panel were still appearing in the user interface. This was happening because:

In the admin panel, models were properly merged with workspace settings (including is_active: false)
In the global model store, only raw model data was used without workspace settings, resulting in is_active: undefined
The ModelSelector was filtering with m.is_active !== false, which didn't exclude models with undefined status
Solution
This PR implements a more robust model store initialization that:

Exports getBaseModels from the API module for proper access to workspace-specific model settings
Updates the global model store initialization to fetch both base models and workspace models
Properly merges these models using the same logic as in the admin panel
Ensures disabled models (is_active: false) are correctly represented throughout the UI
This fix ensures that when an admin disables a model, it properly appears as disabled to all users, maintaining consistent visibility control across the application.