### PR TITLE
  Fix: Restore Model Descriptions in Model Selector UI

### DIFF
--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -37,7 +37,7 @@
 	$: if ($models) {
 		console.log('[ModelSelector] Available models count:', $models.length);
 		console.log('[ModelSelector] Filtered models count:', availableModels.length);
-		
+
 		// Log full model data grouped by source
 		console.log('[ModelSelector] All models grouped by source:', $models.reduce((acc, m) => {
 			const source = m?.owned_by || 'unknown';
@@ -93,11 +93,13 @@
 					<Selector
 						id={`${selectedModelIdx}`}
 						placeholder={$i18n.t('Select a model')}
-						items={availableModels.map((model) => ({
-							value: model.id,
-							label: model.name,
-							model: model
-						}))}
+						items={availableModels.map((model) => {
+							return {
+								value: model.id,
+								label: model.name,
+								model: model
+							};
+						})}
 						showTemporaryChatControl={$user.role === 'user'
 							? ($user?.permissions?.chat?.temporary ?? true)
 							: true}

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -73,12 +73,12 @@
 				...item,
 				modelName: item.model?.name,
 				tags: item.model?.info?.meta?.tags?.map((tag) => tag.name).join(' '),
-				desc: item.model?.info?.meta?.description
+				desc: item.model?.info?.meta?.description || item.model?.description || item.model?.meta?.description
 			};
 			return _item;
 		}),
 		{
-			keys: ['value', 'tags', 'modelName'],
+			keys: ['value', 'tags', 'modelName', 'desc'],
 			threshold: 0.4
 		}
 	);
@@ -402,9 +402,18 @@
 											</Tooltip>
 										</div>
 									</div>
-									{#if item.model?.info?.meta?.description}
+									{#if item.model?.info?.meta?.description || item.model?.description || item.model?.meta?.description}
 										<div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 pl-7 line-clamp-1">
-											{item.model.info.meta.description}
+											{#if item.model?.meta?.description}
+												<!-- Admin edited description -->
+												{item.model.meta.description}
+											{:else if item.model?.info?.meta?.description}
+												<!-- Model info description -->
+												{item.model.info.meta.description}
+											{:else}
+												<!-- Model direct description (Ollama) -->
+												{item.model.description}
+											{/if}
 										</div>
 									{/if}
 									{#if item.model.owned_by === 'ollama' && (item.model.ollama?.details?.parameter_size ?? '') !== ''}


### PR DESCRIPTION
PR Description:
  Summary

  - Fixes a bug where model descriptions were not displaying under model names in the model selector dropdown
  - Adds support for all possible description field locations in the model data structure
  - Prioritizes admin-edited descriptions (from meta.description field) over other description sources

  Technical Details

  This PR addresses an issue where model descriptions configured in the admin model editor were not appearing in the model selector dropdown. The fix adds proper checks for all possible locations where model descriptions can be stored:

  1. model.meta.description - Used by the admin model editor
  2. model.info.meta.description - Used in model info from API
  3. model.description - Used by some model providers (like Ollama)

  The selector now properly prioritizes these sources and displays descriptions regardless of which field contains them, particularly making admin-edited descriptions visible.

  Test Plan

  - Add custom description to a model in the admin workspace
  - Verify the description appears properly in the model selector dropdown
  - Test with different model types to ensure all description sources work correctly