### PR TITLE
Fix: Ensure new models from external sources are disabled by default WEB-85

### DIFF
--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -95,7 +95,7 @@ class Model(Base):
     #      }
     #   }
 
-    is_active = Column(Boolean, default=True)
+    is_active = Column(Boolean, default=False)
 
     updated_at = Column(BigInteger)
     created_at = Column(BigInteger)

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -110,6 +110,37 @@ async def get_all_models(request, user: UserModel = None):
     ]
 
     custom_models = Models.get_all_models()
+    
+    # First, ensure all models from external sources exist in the database
+    # with is_active=False by default for new models
+    model_ids_in_database = set(custom_model.id for custom_model in custom_models)
+    admin_user_id = None
+    
+    # Get admin user for creating default model entries
+    for user in Models.get_admin_users():
+        admin_user_id = user.id
+        break
+        
+    if admin_user_id:
+        for model in models:
+            model_id = model["id"]
+            # Only process models that don't exist in our database yet
+            if model_id not in model_ids_in_database:
+                log.info(f"Creating new model entry with is_active=False for {model_id}")
+                # Create a database entry for this model with is_active=False
+                model_form = {
+                    "id": model_id,
+                    "name": model.get("name", model_id),
+                    "meta": {
+                        "description": model.get("description", ""),
+                        "profile_image_url": "/static/favicon.png",
+                    },
+                    "params": {},
+                    "is_active": False  # Explicitly set to False for new models
+                }
+                Models.insert_new_model(model_form, admin_user_id)
+    
+    # Now process custom models normally
     for custom_model in custom_models:
         if custom_model.base_model_id is None:
             for model in models:


### PR DESCRIPTION
## Description
This PR fixes an issue where new models from external sources (like OpenRouter) were automatically becoming enabled upon discovery. Now all new models will be disabled by default until explicitly enabled by an admin.

## Changes
- Changed the database schema default for `is_active` from `True` to `False` in the `Model` class
- Implemented a synchronization mechanism that proactively creates disabled database entries for newly discovered models
- Ensures only models explicitly enabled by admins are available to users

## Testing
- Verified that the server properly initializes new external models as disabled
- Confirmed existing functionality is preserved for already-configured models

## Related Issues
Addresses the issue where new models from OpenRouter were becoming automatically enabled without admin approval.