### PR TITLE
Remove help icon from bottom right corner of the UI WEB-88

### DIFF
--- a/src/lib/components/layout/Help.svelte
+++ b/src/lib/components/layout/Help.svelte
@@ -10,7 +10,7 @@
 	let showShortcuts = false;
 </script>
 
-<div class=" hidden lg:flex fixed bottom-0 right-0 px-1 py-1 z-20">
+<div class=" hidden lg:hidden fixed bottom-0 right-0 px-1 py-1 z-20">
 	<button
 		id="show-shortcuts-button"
 		class="hidden"


### PR DESCRIPTION

## Description
This PR addresses Web-88 by removing the question mark help icon that was appearing in the bottom right corner of the screen.

## Changes
- Modified the Help.svelte component to hide the question mark icon by changing the CSS class from `hidden lg:flex` to `hidden lg:hidden`

## Testing
- Verified that the help icon no longer appears in the bottom right corner of the screen on desktop view